### PR TITLE
Improve hostkey management, speed up connections

### DIFF
--- a/ssh-into
+++ b/ssh-into
@@ -46,8 +46,8 @@ instance_id_pattern='^m?i-[[:xdigit:]]+$'
 if [[ $REMAINING_INPUT =~ $instance_id_pattern ]]; then
     INSTANCE_ID="$REMAINING_INPUT"
 else
-    DOMAIN="${REMAINING_INPUT#*.}"
     SERVER="${REMAINING_INPUT%%.*}"
+    DOMAIN="${REMAINING_INPUT#*.}"
 
     aws route53 list-hosted-zones --query 'HostedZones[?Name ==`'$DOMAIN'.`].Id' --profile $AWS_PROFILE > /dev/null 2>&1
     if (( $? != 0 )); then
@@ -85,7 +85,7 @@ else
     if [[ -n "$SSH_KEY" ]]; then
         SSH_COMMAND=" -i $SSH_KEY"
     fi
-    SSH_COMMAND="ssh${SSH_COMMAND} $USERNAME@$INSTANCE_ID"
+    SSH_COMMAND="ssh${SSH_COMMAND} -o "HostKeyAlias=${SERVER}.${DOMAIN}" $USERNAME@$INSTANCE_ID"
     echo "$SSH_COMMAND"
     $SSH_COMMAND
 fi

--- a/ssh-into
+++ b/ssh-into
@@ -85,7 +85,10 @@ else
     if [[ -n "$SSH_KEY" ]]; then
         SSH_COMMAND=" -i $SSH_KEY"
     fi
-    SSH_COMMAND="ssh${SSH_COMMAND} -o "HostKeyAlias=${SERVER}.${DOMAIN}" $USERNAME@$INSTANCE_ID"
+    if [[ -n "$SERVER" && -n "$DOMAIN" ]]; then
+        SSH_COMMAND=" -o "HostKeyAlias=${SERVER}.${DOMAIN}""
+    fi
+    SSH_COMMAND="ssh${SSH_COMMAND} $USERNAME@$INSTANCE_ID"
     echo "$SSH_COMMAND"
     $SSH_COMMAND
 fi

--- a/ssh-into
+++ b/ssh-into
@@ -49,14 +49,13 @@ else
     SERVER="${REMAINING_INPUT%%.*}"
     DOMAIN="${REMAINING_INPUT#*.}"
 
-    aws route53 list-hosted-zones --query 'HostedZones[?Name ==`'$DOMAIN'.`].Id' --profile $AWS_PROFILE > /dev/null 2>&1
+    HOSTED_ZONE_ID="$(aws route53 list-hosted-zones --query 'HostedZones[?Name ==`'$DOMAIN'.`].Id' --profile $AWS_PROFILE --output json 2> /dev/null)"
     if (( $? != 0 )); then
         echo -e "You don't appear to have the correct permissions. \nPlease ensure the AWS profile that you're using has the correct Route 53 permissions."
         exit 1
     fi
 
-    HOSTED_ZONE_ID="$(aws route53 list-hosted-zones --query 'HostedZones[?Name ==`'$DOMAIN'.`].Id' --profile $AWS_PROFILE --output json 2> /dev/null | python -c 'import sys, json; print json.load(sys.stdin)[0].split("/")[2]' 2> /dev/null)"
-
+    HOSTED_ZONE_ID="$(python -c 'import sys, json; print json.load(sys.stdin)[0].split("/")[2]' <<< "$HOSTED_ZONE_ID" 2> /dev/null)"
     if [[ "$HOSTED_ZONE_ID" == "null" || -z "$HOSTED_ZONE_ID" ]]; then
         echo "$DOMAIN doesn't appear to be Route 53 Private Hosted Zone in your account. Please double check the domain."
         exit 1


### PR DESCRIPTION
The improved hostkey management should make switching from ssh to ssm more seamless, and I think using the provided name as the hostkeyalias is the behavior users would expect anyway. Additionally I eliminated one of the awscli calls so the script should be around 25% faster when making connections where an instanceid is not provided explicitly.