### PR TITLE
Remove python

### DIFF
--- a/pforward
+++ b/pforward
@@ -63,7 +63,7 @@ resolve_hostname() {
 	if [[ -z "$host" ]]; then
 		return 1
 	fi
-	echo "$(aws route53 list-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --query 'ResourceRecordSets[?Name == `'$host'.`].ResourceRecords[].Value' --profile $AWS_PROFILE --output json 2> /dev/null | python -c 'import sys, json; print json.load(sys.stdin)[0]')"
+	echo "$(aws route53 list-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --query 'ResourceRecordSets[?Name == `'$host'.`].ResourceRecords[].Value' --profile $AWS_PROFILE --output text 2> /dev/null | head -n 1)"
 }
 
 instance_id_pattern='^m?i-[[:xdigit:]]+$'
@@ -74,13 +74,13 @@ else
 	SERVER="${INPUT%%.*}"
 	DOMAIN="${INPUT#*.}"
 
-	HOSTED_ZONE_ID="$(aws route53 list-hosted-zones --query 'HostedZones[?Name ==`'$DOMAIN'.`].Id' --profile $AWS_PROFILE --output json 2> /dev/null)"
+	ZONE_PATH="$(aws route53 list-hosted-zones --query 'HostedZones[?Name ==`'$DOMAIN'.`].Id' --profile $AWS_PROFILE --output text 2> /dev/null)"
 	if (( $? != 0 )); then
 		echo -e "You don't appear to have the correct permissions. \nPlease ensure the AWS profile that you're using has the correct Route 53 permissions."
 		exit 1
 	fi
 
-	HOSTED_ZONE_ID="$(python -c 'import sys, json; print json.load(sys.stdin)[0].split("/")[2]' <<< "$HOSTED_ZONE_ID" 2> /dev/null)"
+	HOSTED_ZONE_ID="${ZONE_PATH##*/}"
 	if [[ "$HOSTED_ZONE_ID" == "null" || -z "$HOSTED_ZONE_ID" ]]; then
 		echo "$DOMAIN doesn't appear to be Route 53 Private Hosted Zone in your account. Please double check the domain."
 		exit 1

--- a/pforward
+++ b/pforward
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 display_usage() {
-	echo -e 'pforward forwards a port over SSM, providing functionality similar to the -D flag for ssh.
+	echo 'pforward forwards a port over SSM, providing functionality similar to the -D flag for ssh.
 Usage: pforward <destination> [options...]
 Destination: Either a hostname (server.env) or an instance-id
 
-Required arguments:
+Required Arguments:
  -r, --remote       Remote port
  -l, --local        Local port
 
@@ -57,10 +57,20 @@ if (( $insufficient_args == 1 )); then
 	exit 1
 fi
 
+resolve_hostname() {
+	local host
+	host="$1"
+	if [[ -z "$host" ]]; then
+		return 1
+	fi
+	echo "$(aws route53 list-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --query 'ResourceRecordSets[?Name == `'$host'.`].ResourceRecords[].Value' --profile $AWS_PROFILE --output json 2> /dev/null | python -c 'import sys, json; print json.load(sys.stdin)[0]')"
+}
+
 instance_id_pattern='^m?i-[[:xdigit:]]+$'
 if [[ $INPUT =~ $instance_id_pattern ]]; then
 	INSTANCE_ID="$INPUT"
 else
+	HOSTNAME="$INPUT"
 	SERVER="${INPUT%%.*}"
 	DOMAIN="${INPUT#*.}"
 
@@ -76,7 +86,20 @@ else
 		exit 1
 	fi
 
-	PRIVATE_IP="$(aws route53 list-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --query 'ResourceRecordSets[?contains(Name,`'$SERVER'`)].ResourceRecords[].Value' --profile $AWS_PROFILE --output json 2> /dev/null | python -c 'import sys, json; print json.load(sys.stdin)[0]' 2> /dev/null)"
+	ip_address_pattern='^([0-9]+(\.|$)){4}'
+	for (( i = 0; i < 10; i++ )); do
+		HOSTNAME="$(resolve_hostname $HOSTNAME)"
+		if [[ $HOSTNAME =~ $ip_address_pattern ]]; then
+			PRIVATE_IP="$HOSTNAME"
+			break
+		fi
+	done
+	if (( i == 10 )); then
+		#dns recursed too far and we didn't get an ip
+		echo "The hostname '$REMAINING_INPUT' couldn't be resolved to an IP."
+		exit 1
+	fi
+
 	INSTANCE_ID="$(aws ec2 describe-instances --profile $AWS_PROFILE --filters 'Name=private-ip-address,Values='$PRIVATE_IP'' --query 'Reservations[].Instances[0].InstanceId' --output text 2> /dev/null)"
 
 	if [[ -z "$INSTANCE_ID" ]]; then

--- a/ssh-into
+++ b/ssh-into
@@ -54,7 +54,7 @@ resolve_hostname() {
 	if [[ -z "$host" ]]; then
 		return 1
 	fi
-	echo "$(aws route53 list-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --query 'ResourceRecordSets[?Name == `'$host'.`].ResourceRecords[].Value' --profile $AWS_PROFILE --output json 2> /dev/null | python -c 'import sys, json; print json.load(sys.stdin)[0]')"
+	echo "$(aws route53 list-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --query 'ResourceRecordSets[?Name == `'$host'.`].ResourceRecords[].Value' --profile $AWS_PROFILE --output text 2> /dev/null | head -n 1)"
 }
 
 instance_id_pattern='^m?i-[[:xdigit:]]+$'
@@ -67,13 +67,13 @@ else
 	SERVER="${REMAINING_INPUT%%.*}"
 	DOMAIN="${REMAINING_INPUT#*.}"
 
-	HOSTED_ZONE_ID="$(aws route53 list-hosted-zones --query 'HostedZones[?Name ==`'$DOMAIN'.`].Id' --profile $AWS_PROFILE --output json 2> /dev/null)"
+	ZONE_PATH="$(aws route53 list-hosted-zones --query 'HostedZones[?Name ==`'$DOMAIN'.`].Id' --profile $AWS_PROFILE --output text 2> /dev/null)"
 	if (( $? != 0 )); then
 		echo -e "You don't appear to have the correct permissions. \nPlease ensure the AWS profile that you're using has the correct Route 53 permissions."
 		exit 1
 	fi
 
-	HOSTED_ZONE_ID="$(python -c 'import sys, json; print json.load(sys.stdin)[0].split("/")[2]' <<< "$HOSTED_ZONE_ID" 2> /dev/null)"
+	HOSTED_ZONE_ID="${ZONE_PATH##*/}"
 	if [[ "$HOSTED_ZONE_ID" == "null" || -z "$HOSTED_ZONE_ID" ]]; then
 		echo "$DOMAIN doesn't appear to be Route 53 Private Hosted Zone in your account. Please double check the domain."
 		exit 1

--- a/ssh-into
+++ b/ssh-into
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 display_usage() {
-    echo -e 'ssh-into connects to an instance over SSM either directly or by using ssh over SSM.
+	echo 'ssh-into connects to an instance over SSM either directly or by using ssh over SSM.
 Usage: ssh-into [user@]<destination> [options...]
 Destination: Either a hostname (server.env) or an instance-id
 
@@ -11,7 +11,10 @@ Optional Arguments:
  -h, --help               Displays this help text'
 }
 
+# modify defaults
 AWS_PROFILE='default'
+USERNAME=''
+SSH_KEY=''
 
 params=( $@ )
 INPUT="$1"
@@ -19,83 +22,106 @@ INPUT="$1"
 # parse args
 i=0
 for arg in "${params[@]}"; do
-    if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
-        display_usage
-        exit 0
-    fi
-    if [[ "$arg" == "-i" || "$arg" == "--identity_file" ]]; then
-        SSH_KEY="${params[$i+1]}"
-    fi
-    if [[ "$arg" == "-p" || "$arg" == "--profile" ]]; then
-        AWS_PROFILE="${params[$i+1]}"
-    fi
-    ((i++))
+	if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+		display_usage
+		exit 0
+	fi
+	if [[ "$arg" == "-i" || "$arg" == "--identity_file" ]]; then
+		SSH_KEY="${params[$i+1]}"
+	fi
+	if [[ "$arg" == "-p" || "$arg" == "--profile" ]]; then
+		AWS_PROFILE="${params[$i+1]}"
+	fi
+	((i++))
 done
 
 # check required args were provided
 if [[ -z "$INPUT" ]]; then
-    echo 'ERROR: No server specified, please specify a server to connect to!' 1>&2
-    display_usage
-    exit 1
+	echo 'ERROR: No server specified, please specify a server to connect to!' 1>&2
+	display_usage
+	exit 1
 fi
 
 # extract username, if provided
 if [[ $INPUT =~ "@" ]]; then
-    USERNAME="${INPUT%%@*}"
+	USERNAME="${INPUT%%@*}"
 fi
 REMAINING_INPUT="${INPUT##*@}"
 
+resolve_hostname() {
+	local host
+	host="$1"
+	if [[ -z "$host" ]]; then
+		return 1
+	fi
+	echo "$(aws route53 list-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --query 'ResourceRecordSets[?Name == `'$host'.`].ResourceRecords[].Value' --profile $AWS_PROFILE --output json 2> /dev/null | python -c 'import sys, json; print json.load(sys.stdin)[0]')"
+}
+
 instance_id_pattern='^m?i-[[:xdigit:]]+$'
 if [[ $REMAINING_INPUT =~ $instance_id_pattern ]]; then
-    # we already have the instance id
-    INSTANCE_ID="$REMAINING_INPUT"
+	# we already have the instance id
+	INSTANCE_ID="$REMAINING_INPUT"
 else
-    # we need to look up the instance id
-    SERVER="${REMAINING_INPUT%%.*}"
-    DOMAIN="${REMAINING_INPUT#*.}"
+	# we need to look up the instance id
+	HOSTNAME="$REMAINING_INPUT"
+	SERVER="${REMAINING_INPUT%%.*}"
+	DOMAIN="${REMAINING_INPUT#*.}"
 
-    HOSTED_ZONE_ID="$(aws route53 list-hosted-zones --query 'HostedZones[?Name ==`'$DOMAIN'.`].Id' --profile $AWS_PROFILE --output json 2> /dev/null)"
-    if (( $? != 0 )); then
-        echo -e "You don't appear to have the correct permissions. \nPlease ensure the AWS profile that you're using has the correct Route 53 permissions."
-        exit 1
-    fi
+	HOSTED_ZONE_ID="$(aws route53 list-hosted-zones --query 'HostedZones[?Name ==`'$DOMAIN'.`].Id' --profile $AWS_PROFILE --output json 2> /dev/null)"
+	if (( $? != 0 )); then
+		echo -e "You don't appear to have the correct permissions. \nPlease ensure the AWS profile that you're using has the correct Route 53 permissions."
+		exit 1
+	fi
 
-    HOSTED_ZONE_ID="$(python -c 'import sys, json; print json.load(sys.stdin)[0].split("/")[2]' <<< "$HOSTED_ZONE_ID" 2> /dev/null)"
-    if [[ "$HOSTED_ZONE_ID" == "null" || -z "$HOSTED_ZONE_ID" ]]; then
-        echo "$DOMAIN doesn't appear to be Route 53 Private Hosted Zone in your account. Please double check the domain."
-        exit 1
-    fi
+	HOSTED_ZONE_ID="$(python -c 'import sys, json; print json.load(sys.stdin)[0].split("/")[2]' <<< "$HOSTED_ZONE_ID" 2> /dev/null)"
+	if [[ "$HOSTED_ZONE_ID" == "null" || -z "$HOSTED_ZONE_ID" ]]; then
+		echo "$DOMAIN doesn't appear to be Route 53 Private Hosted Zone in your account. Please double check the domain."
+		exit 1
+	fi
 
-    PRIVATE_IP="$(aws route53 list-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --query 'ResourceRecordSets[?contains(Name,`'$SERVER'`)].ResourceRecords[].Value' --profile $AWS_PROFILE --output json 2> /dev/null | python -c 'import sys, json; print json.load(sys.stdin)[0]' 2> /dev/null)"
-    INSTANCE_ID="$(aws ec2 describe-instances --profile $AWS_PROFILE --filters 'Name=private-ip-address,Values='$PRIVATE_IP'' --query 'Reservations[].Instances[0].InstanceId' --output text 2> /dev/null)"
+	ip_address_pattern='^([0-9]+(\.|$)){4}'
+	for (( i = 0; i < 10; i++ )); do
+		HOSTNAME="$(resolve_hostname $HOSTNAME)"
+		if [[ $HOSTNAME =~ $ip_address_pattern ]]; then
+			PRIVATE_IP="$HOSTNAME"
+			break
+		fi
+	done
+	if (( i == 10 )); then
+		#dns recursed too far and we didn't get an ip
+		echo "The hostname '$REMAINING_INPUT' couldn't be resolved to an IP."
+		exit 1
+	fi
 
-    if [[ -z "$INSTANCE_ID" ]]; then
-        echo -e "The domain name provided doesn't exist. Please double check the name and try again.\nOR Ensure the the route 53 entry contains a PRIVATE ip address."
-        exit 1
-    fi
-    if [[ ! "$INSTANCE_ID" =~ $instance_id_pattern ]]; then
-        echo "Retrieved instance id $INSTANCE_ID does not seem valid!"
-        exit 1
-    fi
+	INSTANCE_ID="$(aws ec2 describe-instances --profile $AWS_PROFILE --filters 'Name=private-ip-address,Values='$PRIVATE_IP'' --query 'Reservations[].Instances[0].InstanceId' --output text 2> /dev/null)"
 
-    echo "[INFO] Found Private IP for $INSTANCE_ID: $PRIVATE_IP"
+	if [[ -z "$INSTANCE_ID" ]]; then
+		echo -e "The domain name provided doesn't exist. Please double check the name and try again.\nOR Ensure the the route 53 entry contains a PRIVATE ip address."
+		exit 1
+	fi
+	if [[ ! "$INSTANCE_ID" =~ $instance_id_pattern ]]; then
+		echo "Retrieved instance id $INSTANCE_ID does not seem valid!"
+		exit 1
+	fi
+
+	echo "[INFO] Found Private IP for $INSTANCE_ID: $PRIVATE_IP"
 fi
 
 if [[ -z "$USERNAME" ]]; then
-    # connect with ssm directly
-    echo "[INFO] Username not provided, using aws ssm start-session command."
-    # echo "aws ssm start-session --target $INSTANCE_ID --profile $AWS_PROFILE"
-    aws ssm start-session --target $INSTANCE_ID --profile $AWS_PROFILE
+	# connect with ssm directly
+	echo "[INFO] Username not provided, using aws ssm start-session command."
+	# echo "aws ssm start-session --target $INSTANCE_ID --profile $AWS_PROFILE"
+	aws ssm start-session --target $INSTANCE_ID --profile $AWS_PROFILE
 else
-    # connect with ssh over ssm
-    unset SSH_COMMAND
-    if [[ -n "$SSH_KEY" ]]; then
-        SSH_COMMAND=" -i $SSH_KEY"
-    fi
-    if [[ -n "$SERVER" && -n "$DOMAIN" ]]; then
-        SSH_COMMAND="${SSH_COMMAND} -o "HostKeyAlias=${SERVER}.${DOMAIN}""
-    fi
-    SSH_COMMAND="ssh${SSH_COMMAND} $USERNAME@$INSTANCE_ID"
-    echo "$SSH_COMMAND"
-    $SSH_COMMAND
+	# connect with ssh over ssm
+	unset SSH_COMMAND
+	if [[ -n "$SSH_KEY" ]]; then
+		SSH_COMMAND=" -i $SSH_KEY"
+	fi
+	if [[ -n "$SERVER" && -n "$DOMAIN" ]]; then
+		SSH_COMMAND="${SSH_COMMAND} -o "HostKeyAlias=${SERVER}.${DOMAIN}""
+	fi
+	SSH_COMMAND="ssh${SSH_COMMAND} $USERNAME@$INSTANCE_ID"
+	echo "$SSH_COMMAND"
+	$SSH_COMMAND
 fi


### PR DESCRIPTION
Removing python2 is a requirement for getting this code to work on newer versions of macos. This PR is dependent on #10 but could be broken out into its own independent PR if that was desired.